### PR TITLE
feat: Add a no button for the age modal that directs users to caprisun

### DIFF
--- a/src/Components/AgeCheck/AgeCheck.jsx
+++ b/src/Components/AgeCheck/AgeCheck.jsx
@@ -20,6 +20,11 @@ function AgeCheck({ setisLegal }) {
             >
               Yes
             </button>
+            <a href="https://www.caprisun.com/" rel="noopener noreferrer">
+      <button className='no-button content'
+>No</button>
+    </a>
+
           </div>
           <p className='content'>
             Brew Buddy is for individuals of legal drinking age.

--- a/src/Components/AgeCheck/AgeCheck.scss
+++ b/src/Components/AgeCheck/AgeCheck.scss
@@ -35,7 +35,8 @@
     border-radius: 5px;
 }
 
-.yes-button{
+.yes-button,
+.no-button{
   font-size: 1rem;
   height: 2.5rem;
   width: 6rem;
@@ -46,6 +47,13 @@
 .yes-button:hover{
   cursor: pointer;
   background-color: rgb(154, 195, 93);
+  transform: translateY(-3px);
+  box-shadow: 0 1rem 2rem rgba( 0, 0, 0, .5);
+}
+
+.no-button:hover{
+  cursor: pointer;
+  background-color: rgb(247, 2, 2);
   transform: translateY(-3px);
   box-shadow: 0 1rem 2rem rgba( 0, 0, 0, .5);
 }


### PR DESCRIPTION
What I did:

- Add a no button for the age modal that appears when a user first enters the site. If a user clicks no, indicating they aren't 21, then they will be navigated to caprisun's website. 

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [ ]  If this code needs to be tested, all tests are passing
- [ ]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [ ]  I reviewed my code before pushing

What's next?
