### PR TITLE
Trim city input upon form submission

### DIFF
--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -99,6 +99,7 @@ function Search() {
     e.preventDefault();
     dispatchErrorMsg({ type: 'CLEAR_ERROR_MESSAGE' });
 
+    
     if (!city.match(regex)) {
       dispatchErrorMsg({
         type: 'SET_ERROR_MESSAGE',
@@ -120,9 +121,10 @@ function Search() {
       });
       return;
     } else {
+      const formattedCity = city.trim();
       setIsSelected(false)
-      navigate(`/?city=${city}&state=${state}`);
-      obtainBreweries(city, state);
+      navigate(`/?city=${formattedCity}&state=${state}`);
+      obtainBreweries(formattedCity, state);
     }
   }
 


### PR DESCRIPTION
What I did:
- Prevent users from submitting an invalid search if they mistakenly add white space to the beginning or end of a city search parameter.

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [ ]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

Closes #62 