### PR TITLE
feat: Slice the list of us states to only include US states and DC

### DIFF
--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -76,7 +76,7 @@ function Search() {
   }, [formIsReady]);
 
   const states = require('us-state-converter');
-  const listOfStates = states();
+  const listOfStates = states().slice(0, 52);
   const regex = /^[a-zA-Z\s-]*$/;
 
   const noDuplicates = () => {


### PR DESCRIPTION
What I did:

- Fix the drop down options to only include US states and DC 
- closes #61 
Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [ ]  If this code needs to be tested, all tests are passing
- [ ]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [ ]  I reviewed my code before pushing

What's next?
