### PR TITLE
Fix favorite error caused by match  reference not id

### DIFF
--- a/src/Context/FavoriteContext.js
+++ b/src/Context/FavoriteContext.js
@@ -37,7 +37,6 @@ export function FavoriteContextProvider({ children }) {
         );
         return { ...state, favorites: updatedFavorites };
       case 'UPDATE_BY_FAVORITES':
-           
         const favesByLocation = action.breweries.filter(brewery => {
           const favoriteBrewery = state.favorites.find(
             favorite => favorite.id === brewery.id,
@@ -48,7 +47,7 @@ export function FavoriteContextProvider({ children }) {
         });
         return { ...state, filteredBreweries: favesByLocation };
       case 'UPDATE_WITHOUT_FAVORITES':
-        return { ...state, filteredBreweries: action.breweries};
+        return { ...state, filteredBreweries: action.breweries };
       default:
         return state;
     }
@@ -64,7 +63,7 @@ export function FavoriteContextProvider({ children }) {
     filteredBreweries: state.filteredBreweries,
     favorites: state.favorites,
     toggleFavorite: brewery => {
-      if (state.favorites.includes(brewery)) {
+      if (state.favorites.find(favBrewery => favBrewery.id === brewery.id)) {
         dispatch({ type: 'DELETE_FAVORITE', brewery });
       } else {
         dispatch({ type: 'ADD_FAVORITE', brewery });
@@ -75,7 +74,7 @@ export function FavoriteContextProvider({ children }) {
     },
     updateFilteredBreweries: () => {
       if (state.isFaveFilterOn) {
-        dispatch({ type: 'UPDATE_BY_FAVORITES', breweries: breweries});
+        dispatch({ type: 'UPDATE_BY_FAVORITES', breweries: breweries });
       } else {
         dispatch({ type: 'UPDATE_WITHOUT_FAVORITES', breweries: breweries });
       }


### PR DESCRIPTION
What I did:
- Fix bug that caused favorites from local storage to add twice.  This was due to checking if the favorite was is the array by reference instead of id.


Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
